### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "name": "[beta] Serve OpenCV",
   "type": "app",
+  "instance_version": "6.15.60",
   "categories": [
     "neural network",
     "videos",
@@ -9,7 +10,7 @@
     "development"
   ],
   "description": "serve and use in videos annotator",
-  "docker_image": "supervisely/base-py-sdk:6.72.136",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "main_script": "src/main.py",
   "task_location": "application_sessions",
   "icon": "https://imgur.com/a9u0M3Y.png",

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "development"
   ],
   "description": "serve and use in videos annotator",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "task_location": "application_sessions",
   "icon": "https://imgur.com/a9u0M3Y.png",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.136
+supervisely==6.73.564

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import functools
 
 import sly_globals as g
-import supervisely_lib as sly
+import supervisely as sly
 
 from tracker import TrackerContainer
 

--- a/src/sly_functions.py
+++ b/src/sly_functions.py
@@ -1,5 +1,5 @@
 import cv2
-import supervisely_lib as sly
+import supervisely as sly
 import sly_globals as g
 
 

--- a/src/sly_globals.py
+++ b/src/sly_globals.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import pathlib
-import supervisely_lib as sly
+import supervisely as sly
 from dotenv import load_dotenv  # pip install python-dotenv\
 
 logger = sly.logger

--- a/src/tracker.py
+++ b/src/tracker.py
@@ -3,7 +3,7 @@ import cv2
 import sly_functions
 import sly_globals as g
 
-import supervisely_lib as sly
+import supervisely as sly
 
 
 class TrackerContainer:


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
